### PR TITLE
Find specitems defined in table cells

### DIFF
--- a/doc/changes/changes_0.3.0.md
+++ b/doc/changes/changes_0.3.0.md
@@ -1,4 +1,4 @@
-# OpenFastTrace AsciiDoc Plugin 0.3.0, released 2025-03-04
+# OpenFastTrace AsciiDoc Plugin 0.3.0, released 2025-03-05
 
 Code name: Add support for Tags
 

--- a/doc/changes/changes_0.3.0.md
+++ b/doc/changes/changes_0.3.0.md
@@ -1,4 +1,4 @@
-# OpenFastTrace AsciiDoc Plugin 0.3.0, released YYYY-MM-DD
+# OpenFastTrace AsciiDoc Plugin 0.3.0, released 2025-03-04
 
 Code name: Add support for Tags
 
@@ -9,3 +9,7 @@ Starting with this release, OpenFastTrace Tags can be set on specification items
 ## Features
 
 * [Issue #7](https://github.com/itsallcode/openfasttrace-asciidoc-plugin/issues/7): Add support for specifying OpenFastTrace Tags on specitems
+
+## Bug Fixes
+
+* [Issue #8](https://github.com/itsallcode/openfasttrace-asciidoc-plugin/issues/8): Asciidoc importer does not read specification items defined in table cells

--- a/src/main/java/org/itsallcode/openfasttrace/importer/asciidoc/AsciiDocImporter.java
+++ b/src/main/java/org/itsallcode/openfasttrace/importer/asciidoc/AsciiDocImporter.java
@@ -1,13 +1,13 @@
 package org.itsallcode.openfasttrace.importer.asciidoc;
 
 import java.util.*;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.*;
 import org.itsallcode.openfasttrace.api.core.Location;
 import org.itsallcode.openfasttrace.api.core.SpecificationItemId;
 import org.itsallcode.openfasttrace.api.importer.ImportEventListener;
@@ -31,7 +31,8 @@ class AsciiDocImporter implements Importer
     private static final String ROLE_COMMENT = ":comment";
     private static final String ROLE_DESCRIPTION = ":description";
     private static final String ROLE_RATIONALE = ":rationale";
-    private static final String ROLE_SPECITEM = ":specitem";
+
+    private static final String ROLE_NAME_SPECITEM = "specitem";
 
     private static final Logger LOG = Logger.getLogger(AsciiDocImporter.class.getName());
 
@@ -219,6 +220,9 @@ class AsciiDocImporter implements Importer
     // [impl->dsn~adoc-artifact-forwarding-notation~1]
     private void processSpecificationItem(final StructuralNode block)
     {
+        LOG.fine(() -> String.format("found specitem block [id: %s]",
+                block.getId()));
+
         Optional.ofNullable(block.getAttribute(ATTRIBUTE_OFT_SID))
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
@@ -235,6 +239,41 @@ class AsciiDocImporter implements Importer
                                                 Cannot process .specitem [%s]. A .specitem block must \
                                                 have either an 'oft-sid' or an 'oft-skipped' attribute.
                                                 """.formatted(getLocation(block)))));
+    }
+
+    private void processDocument(final Document document)
+    {
+        document.getBlocks().forEach(this::processBlock);
+    }
+
+    private void processBlock(final StructuralNode block)
+    {
+        if (block.hasRole(ROLE_NAME_SPECITEM))
+        {
+            processSpecificationItem(block);
+        }
+        else if (block instanceof final Table table)
+        {
+            processTable(table);
+        }
+        else
+        {
+            block.getBlocks().forEach(this::processBlock);
+        }
+    }
+
+    private void processTable(final Table table)
+    {
+        table.getBody().forEach(row -> row.getCells().forEach(cell -> {
+            final Document innerDocument = cell.getInnerDocument();
+            if (innerDocument != null)
+            {
+                // if the cell has the Asciidoc style, then the content
+                // is itself an Asciidoc Document that may contain
+                // specification items
+                processDocument(innerDocument);
+            }
+        }));
     }
 
     // [impl->dsn~adoc-specification-item-markup~1]
@@ -268,10 +307,6 @@ class AsciiDocImporter implements Importer
     public void runImport()
     {
         final Document document = parseAsciiDoc();
-
-        document.findBy(Map.of(KEY_ROLE, ROLE_SPECITEM)).forEach(node -> {
-            LOG.fine(() -> String.format("found specitem block [id: %s]", node.getId()));
-            processSpecificationItem(node);
-        });
+        processDocument(document);
     }
 }

--- a/src/test/java/org/itsallcode/openfasttrace/importer/asciidoc/AsciiDocImporterTest.java
+++ b/src/test/java/org/itsallcode/openfasttrace/importer/asciidoc/AsciiDocImporterTest.java
@@ -17,163 +17,199 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class AsciiDocImporterTest
 {
-    @Mock
-    private ImportEventListener listener;
-    private InOrder inOrder;
+        @Mock
+        private ImportEventListener listener;
+        private InOrder inOrder;
 
-    @BeforeEach
-    void setup()
-    {
-        inOrder = inOrder(listener);
-    }
+        @BeforeEach
+        void setup()
+        {
+                inOrder = inOrder(listener);
+        }
 
-    @ParameterizedTest
-    @ValueSource(strings =
-    {
-            """
-                    # Spec
+        @ParameterizedTest
+        @ValueSource(strings =
+        {
+                        """
+                                        # Spec
 
-                    [.specitem]
-                    ## A Requirement
-                    """,
-            """
-                    # Spec
+                                        [.specitem]
+                                        ## A Requirement
+                                        """,
+                        """
+                                        # Spec
 
-                    [.specitem]
-                    ====
-                    ====
-                    """
-    })
-    void testImporterIgnoresSpecItemWithoutId(final String content)
-    {
-        final var importer = new AsciiDocImporter(content, listener);
-        importer.runImport();
-        Mockito.verifyNoMoreInteractions(listener);
-    }
+                                        [.specitem]
+                                        ====
+                                        ====
+                                        """
+        })
+        void testImporterIgnoresSpecItemWithoutId(final String content)
+        {
+                final var importer = new AsciiDocImporter(content, listener);
+                importer.runImport();
+                Mockito.verifyNoMoreInteractions(listener);
+        }
 
-    // [utest->dsn~adoc-specification-item-markup~1]
-    // [utest->dsn~adoc-specification-item-id~1]
-    // [utest->dsn~adoc-specification-item-title~1]
-    // [utest->dsn~adoc-specification-item-description~1]
-    // [utest->dsn~adoc-specification-item-rationale~1]
-    // [utest->dsn~adoc-specification-item-comment~1]
-    // [utest->dsn~adoc-depends-list~1]
-    // [utest->dsn~adoc-covers-list~1]
-    // [utest->dsn~adoc-needs-coverage-list~1]
-    @ParameterizedTest
-    @ValueSource(strings =
-    {
-            """
-                    # Spec
+        // [utest->dsn~adoc-specification-item-markup~1]
+        // [utest->dsn~adoc-specification-item-id~1]
+        // [utest->dsn~adoc-specification-item-title~1]
+        // [utest->dsn~adoc-specification-item-description~1]
+        // [utest->dsn~adoc-specification-item-rationale~1]
+        // [utest->dsn~adoc-specification-item-comment~1]
+        // [utest->dsn~adoc-depends-list~1]
+        // [utest->dsn~adoc-covers-list~1]
+        // [utest->dsn~adoc-needs-coverage-list~1]
+        @ParameterizedTest
+        @ValueSource(strings =
+        {
+                        """
+                                        # Spec
 
-                    [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
-                    ## A Requirement
+                                        [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
+                                        ## A Requirement
 
-                    The description
+                                        The description
 
-                    [.rationale]
-                    The rationale
+                                        [.rationale]
+                                        The rationale
 
-                    [.comment]
-                    A comment
-                    """,
-            """
-                    # Spec
+                                        [.comment]
+                                        A comment
+                                        """,
+                        """
+                                        # Spec
 
-                    [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
-                    ## A Requirement
+                                        [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
+                                        ## A Requirement
 
-                    [.rationale]
-                    The rationale
+                                        [.rationale]
+                                        The rationale
 
-                    [.description]
-                    The description
+                                        [.description]
+                                        The description
 
-                    [.comment]
-                    A comment
-                    """,
-            """
-                    # Spec
+                                        [.comment]
+                                        A comment
+                                        """,
+                        """
+                                        # Spec
 
-                    .A Requirement
-                    [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
-                    ====
+                                        .A Requirement
+                                        [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
+                                        ====
 
-                    The description
+                                        The description
 
-                    [.rationale]
-                    The rationale
+                                        [.rationale]
+                                        The rationale
 
-                    [.comment]
-                    A comment
-                    ====
-                    """,
-            """
-                    # Spec
+                                        [.comment]
+                                        A comment
+                                        ====
+                                        """,
+                        """
+                                        # Spec
 
-                    .A Requirement
-                    [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
-                    ====
+                                        .A Requirement
+                                        [.specitem, oft-sid="dsn~detail-design~1", oft-depends="dsn~grand-design~1, arch~general-constraints~1", oft-needs="impl, utest", oft-covers="req~first-requirement~1, req~second-requirement~1", oft-tags="Priority1, OtherComponent"]
+                                        ====
 
-                    [.rationale]
-                    The rationale
+                                        [.rationale]
+                                        The rationale
 
-                    [.description]
-                    The description
+                                        [.description]
+                                        The description
 
-                    [.comment]
-                    A comment
-                    ====
-                    """
-    })
-    void testImporterReadsFullSpecItem(final String content)
-    {
-        final var importer = new AsciiDocImporter(content, listener);
-        importer.runImport();
-        inOrder.verify(listener).beginSpecificationItem();
-        Mockito.verify(listener).setId(new SpecificationItemId.Builder("dsn~detail-design~1").build());
-        Mockito.verify(listener).setLocation(any());
-        Mockito.verify(listener).setTitle("A Requirement");
-        Mockito.verify(listener).addDependsOnId(new SpecificationItemId.Builder("dsn~grand-design~1").build());
-        Mockito.verify(listener).addDependsOnId(new SpecificationItemId.Builder("arch~general-constraints~1").build());
-        Mockito.verify(listener).addNeededArtifactType("impl");
-        Mockito.verify(listener).addNeededArtifactType("utest");
-        Mockito.verify(listener).addCoveredId(new SpecificationItemId.Builder("req~first-requirement~1").build());
-        Mockito.verify(listener).addCoveredId(new SpecificationItemId.Builder("req~second-requirement~1").build());
-        Mockito.verify(listener).addTag("Priority1");
-        Mockito.verify(listener).addTag("OtherComponent");
-        Mockito.verify(listener).appendDescription("The description");
-        Mockito.verify(listener).appendRationale("The rationale");
-        Mockito.verify(listener).appendComment("A comment");
-        inOrder.verify(listener).endSpecificationItem();
-        Mockito.verifyNoMoreInteractions(listener);
-    }
+                                        [.comment]
+                                        A comment
+                                        ====
+                                        """
+        })
+        void testImporterReadsFullSpecItem(final String content)
+        {
+                final var importer = new AsciiDocImporter(content, listener);
+                importer.runImport();
+                inOrder.verify(listener).beginSpecificationItem();
+                Mockito.verify(listener).setId(new SpecificationItemId.Builder("dsn~detail-design~1").build());
+                Mockito.verify(listener).setLocation(any());
+                Mockito.verify(listener).setTitle("A Requirement");
+                Mockito.verify(listener).addDependsOnId(new SpecificationItemId.Builder("dsn~grand-design~1").build());
+                Mockito.verify(listener)
+                                .addDependsOnId(new SpecificationItemId.Builder("arch~general-constraints~1").build());
+                Mockito.verify(listener).addNeededArtifactType("impl");
+                Mockito.verify(listener).addNeededArtifactType("utest");
+                Mockito.verify(listener)
+                                .addCoveredId(new SpecificationItemId.Builder("req~first-requirement~1").build());
+                Mockito.verify(listener)
+                                .addCoveredId(new SpecificationItemId.Builder("req~second-requirement~1").build());
+                Mockito.verify(listener).addTag("Priority1");
+                Mockito.verify(listener).addTag("OtherComponent");
+                Mockito.verify(listener).appendDescription("The description");
+                Mockito.verify(listener).appendRationale("The rationale");
+                Mockito.verify(listener).appendComment("A comment");
+                inOrder.verify(listener).endSpecificationItem();
+                Mockito.verifyNoMoreInteractions(listener);
+        }
 
-    // [utest->dsn~adoc-artifact-forwarding-notation~1]
-    @Test
-    void testImporterReadsForwardingSpecItem()
-    {
-        final var content = """
-                        # Spec
+        // [utest->dsn~adoc-artifact-forwarding-notation~1]
+        @Test
+        void testImporterReadsForwardingSpecItem()
+        {
+                final var content = """
+                                # Spec
 
-                        ## Design
+                                ## Design
 
-                        [.specitem, oft-skipped="dsn", oft-needs="impl, utest", oft-covers="req~first-requirement~1"]
-                        --
-                        --
-                        """;
-        final var importer = new AsciiDocImporter(content, listener);
-        importer.runImport();
-        inOrder.verify(listener).beginSpecificationItem();
-        Mockito.verify(listener)
-                .setId(new SpecificationItemId.Builder("dsn~first-requirement~1").build());
-        Mockito.verify(listener).setLocation(
-                        argThat(location -> "verbatim".equals(location.getPath()) && location.getLine() == 6));
-        Mockito.verify(listener).addNeededArtifactType("impl");
-        Mockito.verify(listener).addNeededArtifactType("utest");
-        Mockito.verify(listener)
-                .addCoveredId(new SpecificationItemId.Builder("req~first-requirement~1").build());
-        inOrder.verify(listener).endSpecificationItem();
-        Mockito.verifyNoMoreInteractions(listener);
-    }
+                                [.specitem, oft-skipped="dsn", oft-needs="impl, utest", oft-covers="req~first-requirement~1"]
+                                --
+                                --
+                                """;
+                final var importer = new AsciiDocImporter(content, listener);
+                importer.runImport();
+                inOrder.verify(listener).beginSpecificationItem();
+                Mockito.verify(listener)
+                                .setId(new SpecificationItemId.Builder("dsn~first-requirement~1").build());
+                Mockito.verify(listener).setLocation(
+                                argThat(location -> "verbatim".equals(location.getPath()) && location.getLine() == 6));
+                Mockito.verify(listener).addNeededArtifactType("impl");
+                Mockito.verify(listener).addNeededArtifactType("utest");
+                Mockito.verify(listener)
+                                .addCoveredId(new SpecificationItemId.Builder("req~first-requirement~1").build());
+                inOrder.verify(listener).endSpecificationItem();
+                Mockito.verifyNoMoreInteractions(listener);
+        }
+
+        @Test
+        void testImporterReadsSpecItemNestedInTableCell()
+        {
+                final var content = """
+                                .Test Table
+                                [%autowidth]
+                                |===
+                                |Column 1 |Column 2
+
+                                |Default Style
+                                a|
+                                Asciidoc Style
+
+                                [.specitem, oft-sid="req~nested-in-table~1", oft-needs="dsn"]
+                                --
+                                The description
+                                --
+                                |===
+                                """;
+                final var importer = new AsciiDocImporter(content, listener);
+                importer.runImport();
+                inOrder.verify(listener).beginSpecificationItem();
+                Mockito.verify(listener)
+                                .setId(new SpecificationItemId.Builder("req~nested-in-table~1").build());
+                Mockito.verify(listener).setLocation(
+                                argThat(location -> "verbatim".equals(location.getPath())));
+                Mockito.verify(listener).addNeededArtifactType("dsn");
+                Mockito.verify(listener).appendDescription("The description");
+                inOrder.verify(listener).endSpecificationItem();
+                Mockito.verifyNoMoreInteractions(listener);
+        }
+
 }


### PR DESCRIPTION
The Asciidoc Importer has been changed to also find specification
items that are defined in table cells having the Asciidoc style.

Addresses #8